### PR TITLE
module naming convention

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ title: Golo &mdash; a lightweight dynamic language for the JVM.
   <div class="row">
     <div class="span4">
       <p class="golo-code">
-        <span class="keyword">module</span> <span class="identifier">hello.world</span><br>
+        <span class="keyword">module</span> <span class="identifier">hello.World</span><br>
         <br>
         <span class="keyword">function</span> <span class="identifier">main</span> = |<span class="arg">args</span>| {                  <br>
           &nbsp;&nbsp;println(<span class="string">"Hello world")</span><br>


### PR DESCRIPTION
> It is suggested yet not enforced that the first elements in a module name are in lowercase, and that the last one have an uppercase first letter.

[Link to the point in the documentation](http://golo-lang.org/documentation/next/#_hello_world)
